### PR TITLE
Update service control to use rc.init RPC API

### DIFF
--- a/luci-app-zapret2/htdocs/luci-static/resources/view/zapret2/tools.js
+++ b/luci-app-zapret2/htdocs/luci-static/resources/view/zapret2/tools.js
@@ -78,10 +78,10 @@ return baseclass.extend({
     }),
 
     callInitAction: rpc.declare({
-        object: 'luci',
-        method: 'setInitAction',
+        object: 'rc',
+        method: 'init',
         params: [ 'name', 'action' ],
-        expect: { result: false }
+        expect: { '': {} }
     }),
 
     getSvcInfo: function(svc_name = null) {
@@ -146,9 +146,6 @@ return baseclass.extend({
     {
         console.log('handleServiceAction: '+name+' '+action);
         return this.callInitAction(name, action).then(success => {
-            if (!success) {
-                throw _('Command failed');
-            }
             return true;
         }).catch(e => {
             ui.addNotification(null, E('p', _('Service action failed "%s %s": %s').format(name, action, e)));

--- a/luci-app-zapret2/root/usr/share/rpcd/acl.d/luci-app-zapret2.json
+++ b/luci-app-zapret2/root/usr/share/rpcd/acl.d/luci-app-zapret2.json
@@ -28,6 +28,7 @@
 			}
 		},
 		"write": {
+                "ubus": { "rc": [ "init" ] },
 			"file": {
 				"/opt/zapret2/config": [ "write" ],
 				"/opt/zapret2/ipset/*": [ "write" ],


### PR DESCRIPTION
## What does this PR do?

Updates the LuCI service control implementation to use the `rc.init` ubus API instead of the deprecated/unsupported `luci.setInitAction` method.

### Changes

- Replace `luci.setInitAction` with `rc.init`
- Update the RPC `expect` definition for the new API
- Remove the old boolean success check
- Add `rc.init` permission to the package rpcd ACL

This fixes service start/stop/restart actions on newer OpenWrt versions.